### PR TITLE
Fixed a bug in the input when reducing the number of units of the product.

### DIFF
--- a/script.js
+++ b/script.js
@@ -128,6 +128,7 @@ const renderCartItem = (product, inputNumber) => {
   quantity.type = "number";
   quantity.value = inputNumber || 1;
   quantity.min = 1;
+  quantity.className = "quantity-input";
   removeBtn.innerText = "REMOVE";
   emptyCartTitle.style.display = "none";
   cartListWrapper.style.display = "block";
@@ -162,8 +163,16 @@ const saveProduct = (product) => {
     (item) => item.id === product.id
   );
   if (productInCart > -1) {
-    product.amount++;
-    currentCartProducts.splice(productInCart, 1, product);
+    const qtyInput = document.getElementsByClassName("quantity-input");
+    if (
+      qtyInput[productInCart].value > currentCartProducts[productInCart].amount
+    ) {
+      product.amount++;
+      currentCartProducts.splice(productInCart, 1, product);
+    } else {
+      product.amount--;
+      currentCartProducts.splice(productInCart, 1, product);
+    }
   } else {
     product.amount = 1;
     currentCartProducts.push(product);


### PR DESCRIPTION
Noticed a bug in the application, if you add several units of the same product to the basket, and then reduce their quantity (for example, first add 3 units, and then reduce to two), then there will be four units in the local storage, because according to the code (starting from line 164 ) with any manipulation of the number of product units (add or subtract), product.amount increases by one unit.